### PR TITLE
Bump Azure.Identity from 1.17.0 to 1.17.1 in all projects

### DIFF
--- a/Altinn.Dan.Plugin.Statensvegvesen.Test/Altinn.Dan.Plugin.Statensvegvesen.Test.csproj
+++ b/Altinn.Dan.Plugin.Statensvegvesen.Test/Altinn.Dan.Plugin.Statensvegvesen.Test.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/src/Altinn.Dan.Plugin.Statensvegvesen/Altinn.Dan.Plugin.Statensvegvesen.csproj
+++ b/src/Altinn.Dan.Plugin.Statensvegvesen/Altinn.Dan.Plugin.Statensvegvesen.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.2.1" />
-    <PackageReference Include="Azure.Identity" Version="1.17.1" />
+    <PackageReference Include="Azure.Identity" Version="1.17.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="Dan.Common" Version="1.11.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />

--- a/src/Altinn.Dan.Plugin.Statensvegvesen/Altinn.Dan.Plugin.Statensvegvesen.csproj
+++ b/src/Altinn.Dan.Plugin.Statensvegvesen/Altinn.Dan.Plugin.Statensvegvesen.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.2.1" />
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
+    <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
     <PackageReference Include="Dan.Common" Version="1.11.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />


### PR DESCRIPTION
Reverts data-altinn-no/plugin-statensvegvesen#13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Azure.Identity dependency to the latest patch version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->