### PR TITLE
DAN-259: replaced Moq with FakeItEasy

### DIFF
--- a/Altinn.Dan.Plugin.Statensvegvesen.Test/Altinn.Dan.Plugin.Statensvegvesen.Test.csproj
+++ b/Altinn.Dan.Plugin.Statensvegvesen.Test/Altinn.Dan.Plugin.Statensvegvesen.Test.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="StackExchange.Redis" Version="2.10.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/Altinn.Dan.Plugin.Statensvegvesen.Test/Clients/SvvClientTest.cs
+++ b/Altinn.Dan.Plugin.Statensvegvesen.Test/Clients/SvvClientTest.cs
@@ -1,11 +1,11 @@
 using System.Net.Http;
-using Moq;
+using FakeItEasy;
 
 namespace Altinn.Dan.Plugin.Statensvegvesen.Test.Clients;
 
 public class SvvClientTest
 {
-    private readonly Mock<IHttpClientFactory> _httpClientFactory = new Mock<IHttpClientFactory>();
+    private readonly IHttpClientFactory _httpClientFactory = A.Fake<IHttpClientFactory>();
     /*
     [Fact]
     public async Task SokKjoretoyForFodselsnummer_ok()

--- a/Altinn.Dan.Plugin.Statensvegvesen.Test/TestHelpers/TestHelpers.cs
+++ b/Altinn.Dan.Plugin.Statensvegvesen.Test/TestHelpers/TestHelpers.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
 using FakeItEasy;
 using Newtonsoft.Json;
@@ -40,7 +39,7 @@ namespace Altinn.Dan.Plugin.Statensvegvesen.Test.TestUtils
 
             // Configure the fake to throw an exception
             A.CallTo(handler)
-                .Where(call => call.Method.Name=="SendAsync")
+                .Where(call => call.Method.Name == "SendAsync")
                 .WithReturnType<Task<HttpResponseMessage>>()
                 .Throws(new HttpRequestException("Connection refused"));
 

--- a/Altinn.Dan.Plugin.Statensvegvesen.Test/TestHelpers/TestHelpers.cs
+++ b/Altinn.Dan.Plugin.Statensvegvesen.Test/TestHelpers/TestHelpers.cs
@@ -1,29 +1,44 @@
-using Moq;
-using Moq.Protected;
-using Newtonsoft.Json;
 using System;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using FakeItEasy;
+using Newtonsoft.Json;
 
 namespace Altinn.Dan.Plugin.Statensvegvesen.Test.TestUtils
 {
     public static class TestHelpers
     {
+        // Derived class to allow faking the protected SendAsync
+        public class TestHttpMessageHandler : HttpMessageHandler
+        {
+            public virtual Task<HttpResponseMessage> SendAsyncPublic(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return SendAsync(request, cancellationToken);
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                // Default implementation
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+        }
+
         public static HttpClient GetHttpClientMock(HttpStatusCode httpStatusCode = HttpStatusCode.OK, string responseBody = "")
         {
-            var handler = new Mock<HttpMessageHandler>();
-            handler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(new HttpResponseMessage
-                    {
-                        StatusCode = httpStatusCode,
-                        Content = new StringContent(responseBody)
-                    }
-                );
-            var httpClient = new HttpClient(handler.Object);
+            var handler = A.Fake<TestHttpMessageHandler>();
+
+            // Configure the fake to return the response
+            A.CallTo(() => handler.SendAsyncPublic(A<HttpRequestMessage>._, A<CancellationToken>._))
+                .Returns(Task.FromResult(new HttpResponseMessage
+                {
+                    StatusCode = httpStatusCode,
+                    Content = new StringContent(responseBody)
+                }));
+
+            var httpClient = new HttpClient(handler);
             httpClient.BaseAddress = new Uri("http://localhost");
 
             return httpClient;
@@ -31,11 +46,13 @@ namespace Altinn.Dan.Plugin.Statensvegvesen.Test.TestUtils
 
         public static HttpClient GetHttpClientExceptionMock()
         {
-            var handler = new Mock<HttpMessageHandler>();
-            handler.Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            var handler = A.Fake<TestHttpMessageHandler>();
+
+            // Configure the fake to throw an exception
+            A.CallTo(() => handler.SendAsyncPublic(A<HttpRequestMessage>._, A<CancellationToken>._))
                 .Throws(new HttpRequestException("Connection refused"));
-            var httpClient = new HttpClient(handler.Object);
+
+            var httpClient = new HttpClient(handler);
             httpClient.BaseAddress = new Uri("http://localhost");
 
             return httpClient;


### PR DESCRIPTION
### Description
<!--- What and why -->

### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced the mocking framework in the test suite to standardize test patterns and simplify mocks; test helpers and client tests updated accordingly.
  * No changes to public APIs or runtime behavior; test logic adjusted only.

* **Chores**
  * Updated test project dependencies to reflect the new mocking library and removed the previous mocking dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->